### PR TITLE
Fix Firestore connection test invocation

### DIFF
--- a/js/firebaseretrieve.js
+++ b/js/firebaseretrieve.js
@@ -17,7 +17,7 @@ const db = getFirestore(app);
     } catch (error) {
         console.error("Firestore connection failed:", error);
     }
-});
+})();
 
 /**
  * Fetch waste form data from Firestore.


### PR DESCRIPTION
## Summary
- fix immediate invocation in `testFirestoreConnection` so the Firestore check executes

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c120b9a588320baf355f099503b17