### PR TITLE
Fix link references to calculator.html

### DIFF
--- a/pages/employeeDashboard.html
+++ b/pages/employeeDashboard.html
@@ -214,7 +214,7 @@
                 <div class="dashboard-card">
                     <h3>Carbon Emission</h3>
                     <canvas id="liquidWasteChart"></canvas>
-                    <a href="Calculator.html">
+                    <a href="calculator.html">
                         <button>Let's Calculate!</button>
                     </a>
                 </div>

--- a/pages/homepage.html
+++ b/pages/homepage.html
@@ -216,7 +216,7 @@
                 <div class="dashboard-card">
                     <h3>Carbon Emission</h3>
                     <canvas id="liquidWasteChart"></canvas>
-                    <a href="Calculator.html">
+                    <a href="calculator.html">
                         <button id="addLiquidWaste">Lets Calculate !</button>
                     </a>
                 </div>


### PR DESCRIPTION
## Summary
- update employeeDashboard and homepage to link to `calculator.html`

## Testing
- `grep -R "Calculator.html" -n`


------
https://chatgpt.com/codex/tasks/task_e_685c12da28ac83208719c10e544d6250